### PR TITLE
Move default prefix selection to Manager Preferences window

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,16 +64,17 @@ int main(int argc, char *argv[])
             managerCfg->beginGroup("NeroSettings");
 
             // One-time runner (executable only) when DefaultPrefix set 
-            if(argc < 3 && (arguments.last().endsWith(".exe") || arguments.last().endsWith(".msi") || arguments.last().endsWith(".bat")) && 
-                !managerCfg->value("DefaultPrefix").isNull()) {
+            if(argc < 3 && (arguments.last().endsWith(".exe") || arguments.last().endsWith(".msi") || arguments.last().endsWith(".bat")) 
+                && !managerCfg->value("DefaultPrefix").toString().isEmpty()
+                && managerCfg->value("RunWithDefaultPrefix").toBool()) {
 
-                printf("Requested to open file!\n");
+                printf("Launching with default prefix: %s\n", qPrintable(managerCfg->value("DefaultPrefix").toString()));
 
                 NeroFS::SetCurrentPrefix(managerCfg->value("DefaultPrefix").toString());
                 NeroRunner runner;
                 return runner.StartOnetime(arguments.last(), {});
             // One-time runner (executable only) - prompt user for prefix
-            } else if(managerCfg->value("DefaultPrefix").isNull()) {
+            } else if(!managerCfg->value("RunWithDefaultPrefix").toBool() || managerCfg->value("DefaultPrefix").toString().isEmpty()) {
                 NeroOneTimeDialog oneTimeDiag;
                 oneTimeDiag.exec();
 

--- a/src/neromanager.h
+++ b/src/neromanager.h
@@ -109,7 +109,6 @@ public slots:
     void handleUmuSignal(const int &);
 
 private slots:
-    void prefixDefaultButtons_clicked();
     void prefixMainButtons_clicked();
     void prefixDeleteButtons_clicked();
     void prefixShortcutPlayButtons_clicked();
@@ -178,7 +177,6 @@ private:
     QStringList oneOffsRunning;
 
     // Prefixes list assets
-    QList<QPushButton*> prefixDefaultButton;
     QList<QPushButton*> prefixMainButton;
     QList<QPushButton*> prefixDeleteButton;
 

--- a/src/neromanager.ui
+++ b/src/neromanager.ui
@@ -150,6 +150,9 @@
             <bold>false</bold>
            </font>
           </property>
+          <property name="text">
+           <string>Run Executable in Prefix...</string>
+          </property>
           <property name="icon">
            <iconset theme="media-playback-start"/>
           </property>

--- a/src/neropreferences.cpp
+++ b/src/neropreferences.cpp
@@ -18,19 +18,26 @@
 */
 
 #include "neropreferences.h"
+#include "nerofs.h"
 #include "ui_neropreferences.h"
 
 #include <QShortcut>
+#include <QCheckBox>
 
 NeroManagerPreferences::NeroManagerPreferences(QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::NeroManagerPreferences)
 {
     ui->setupUi(this);
+    // make window non-resizeable
+    setFixedSize(sizeHint());
 
     // shortcut ctrl/cmd + W to close the popup window
 	QShortcut *shortcutClose = new QShortcut(QKeySequence::Close, this);
 	connect(shortcutClose, &QShortcut::activated, this,&NeroManagerPreferences::close);
+
+    ui->defaultPrefix->addItems(NeroFS::GetPrefixes());
+    connect(ui->defaultPrefixStart, &QCheckBox::clicked, this, &NeroManagerPreferences::on_defaultPrefixStart_clicked);
 }
 
 NeroManagerPreferences::~NeroManagerPreferences()
@@ -38,6 +45,8 @@ NeroManagerPreferences::~NeroManagerPreferences()
     if(accepted) {
         //managerCfg->setValue("UseNotifier", ui->runnerNotifs->isChecked());
         managerCfg->setValue("ShortcutHidesManager", ui->shortcutHide->isChecked());
+        managerCfg->setValue("RunWithDefaultPrefix", ui->defaultPrefixStart->isChecked());
+        managerCfg->setValue("DefaultPrefix", ui->defaultPrefix->currentText());
     }
     delete ui;
 }
@@ -47,4 +56,12 @@ void NeroManagerPreferences::BindSettings(QSettings *cfg)
     managerCfg = cfg;
     //ui->runnerNotifs->setChecked(managerCfg->value("UseNotifier").toBool());
     ui->shortcutHide->setChecked(managerCfg->value("ShortcutHidesManager").toBool());
+    ui->defaultPrefixStart->setChecked(managerCfg->value("RunWithDefaultPrefix").toBool());
+    ui->defaultPrefix->setCurrentText(managerCfg->value("DefaultPrefix").toString());
+    ui->defaultPrefix->setEnabled(ui->defaultPrefixStart->isChecked());
+}
+
+void NeroManagerPreferences::on_defaultPrefixStart_clicked()
+{
+    ui->defaultPrefix->setEnabled(ui->defaultPrefixStart->isChecked());
 }

--- a/src/neropreferences.h
+++ b/src/neropreferences.h
@@ -43,6 +43,7 @@ private:
     Ui::NeroManagerPreferences *ui;
     QSettings *managerCfg;
     bool accepted = false;
+    void on_defaultPrefixStart_clicked();
 };
 
 #endif // NEROPREFERENCES_H

--- a/src/neropreferences.ui
+++ b/src/neropreferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>241</width>
-    <height>74</height>
+    <width>619</width>
+    <height>142</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,27 +16,42 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QCheckBox" name="shortcutHide">
-     <property name="text">
-      <string>Hide to System Tray when starting shortcuts
-(Nero Manager will unhide when shortcut ends)</string>
+    <layout class="QVBoxLayout" name="options">
+     <property name="topMargin">
+      <number>10</number>
      </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+     <property name="bottomMargin">
+      <number>10</number>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+     <item>
+      <widget class="QCheckBox" name="shortcutHide">
+       <property name="text">
+        <string>Hide to System Tray when starting shortcuts (Nero Manager will unhide when shortcut ends)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="defaultPrefixStartBox">
+       <item>
+        <widget class="QCheckBox" name="defaultPrefixStart">
+         <property name="text">
+          <string>Use default prefix to launch executables when given as a parameter
+(ex. When launching from a file manager)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="defaultPrefix">
+         <property name="placeholderText">
+          <string>Select Default Prefix</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
After trying a whole bunch of ui options and testing with other users, I decided on simply moving everything to the preferences window. Reasons for this are:
* Most users will not use this or want to use this.
* Adding this to the main window adds visual clutter no matter what.
* And when added to the main window with no description this is a regression for most users since most of the people I talked to _want_ to select the prefix everytime.

Also sorry this took so long, as I said I only reached this point after a lot of remaking ui, testing with users, then doing it again.